### PR TITLE
revert to winston 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "request": "2.88.0",
     "session-file-store": "1.2.0",
     "superagent": "3.7.0",
-    "winston": "3.1.0"
+    "winston": "^2.1.1"
   },
   "bin": {
     "pheme-server": "./bin/server.js"


### PR DESCRIPTION
https://github.com/w3c/pheme/commit/21521b07255424937bd4e1f38113eccf16017d0c introduced a breaking change with the major upgrade of winston.
That PR reverts back to the old version.